### PR TITLE
Remove state machine from Spree::Shipment

### DIFF
--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -4,6 +4,13 @@ module Spree
   # An order's planned shipments including tracking and cost.
   #
   class Shipment < Spree::Base
+    class InvalidStateChange < StandardError; end
+
+    READY = 'ready'
+    PENDING = 'pending'
+    SHIPPED = 'shipped'
+    CANCELED = 'canceled'
+
     belongs_to :order, class_name: 'Spree::Order', touch: true, inverse_of: :shipments
     belongs_to :stock_location, class_name: 'Spree::StockLocation'
 
@@ -13,6 +20,10 @@ module Spree
     has_many :shipping_methods, through: :shipping_rates
     has_many :state_changes, as: :stateful
     has_many :cartons, -> { uniq }, through: :inventory_units
+
+    validates :state, presence: true, inclusion: { in: [READY, PENDING, SHIPPED, CANCELED] }
+
+    after_initialize :set_default_state
 
     before_validation :set_cost_zero_when_nil
 
@@ -26,49 +37,111 @@ module Spree
 
     make_permalink field: :number, length: 11, prefix: 'H'
 
-    scope :pending, -> { with_state('pending') }
-    scope :ready,   -> { with_state('ready') }
-    scope :shipped, -> { with_state('shipped') }
+    scope :pending, -> { with_state(PENDING) }
+    scope :ready,   -> { with_state(READY) }
+    scope :shipped, -> { with_state(SHIPPED) }
     scope :trackable, -> { where("tracking IS NOT NULL AND tracking != ''") }
     scope :with_state, ->(*s) { where(state: s) }
     # sort by most recent shipped_at, falling back to created_at. add "id desc" to make specs that involve this scope more deterministic.
     scope :reverse_chronological, -> { order('coalesce(spree_shipments.shipped_at, spree_shipments.created_at) desc', id: :desc) }
     scope :by_store, ->(store) { joins(:order).merge(Spree::Order.by_store(store)) }
 
-    # shipment state machine (see http://github.com/pluginaweek/state_machine/tree/master for details)
-    state_machine initial: :pending, use_transactions: false do
-      event :ready do
-        transition from: :pending, to: :shipped, if: :can_transition_from_pending_to_shipped?
-        transition from: :pending, to: :ready, if: :can_transition_from_pending_to_ready?
-      end
+    def cancel!
+      cancel || (raise InvalidStateChange)
+    end
 
-      event :pend do
-        transition from: :ready, to: :pending
-      end
+    def cancel
+      return false unless can_cancel?
+      change_state!(CANCELED)
+      after_cancel
+      true
+    end
 
-      event :ship do
-        transition from: [:ready, :canceled], to: :shipped
-      end
-      after_transition to: :shipped, do: :after_ship
+    def can_cancel?
+      ready_or_pending?
+    end
 
-      event :cancel do
-        transition to: :canceled, from: [:pending, :ready]
-      end
-      after_transition to: :canceled, do: :after_cancel
+    def canceled?
+      state == CANCELED
+    end
 
-      event :resume do
-        transition from: :canceled, to: :ready, if: :can_transition_from_canceled_to_ready?
-        transition from: :canceled, to: :pending
-      end
-      after_transition from: :canceled, to: [:pending, :ready, :shipped], do: :after_resume
+    def resume!
+      resume || (raise InvalidStateChange)
+    end
 
-      after_transition do |shipment, transition|
-        shipment.state_changes.create!(
-          previous_state: transition.from,
-          next_state:     transition.to,
-          name:           'shipment'
-        )
+    def resume
+      return false unless can_resume?
+      can_transition_from_canceled_to_ready? ? change_state!(READY) : change_state!(PENDING)
+      after_resume
+      true
+    end
+
+    def can_resume?
+      canceled?
+    end
+
+    def ship!
+      ship || (raise InvalidStateChange)
+    end
+
+    def ship
+      return false unless can_ship?
+      previous_state = state
+      change_state!(SHIPPED)
+      after_ship
+      after_resume if previous_state == CANCELED
+      true
+    end
+
+    def can_ship?
+      ready? || canceled?
+    end
+
+    def shipped?
+      state == SHIPPED
+    end
+
+    def ready!
+      ready || (raise InvalidStateChange)
+    end
+
+    def ready
+      return false unless state == PENDING
+      if can_transition_from_pending_to_shipped?
+        change_state!(SHIPPED)
+        after_ship
+      elsif can_transition_from_pending_to_ready?
+        change_state!(READY)
+      else
+        return false
       end
+      true
+    end
+
+    def ready?
+      state == READY
+    end
+
+    def can_ready?
+      pending? && (can_transition_from_pending_to_shipped? || can_transition_from_pending_to_ready?)
+    end
+
+    def pend!
+      pend || (raise InvalidStateChange)
+    end
+
+    def pend
+      return false unless can_pend?
+      change_state!(PENDING)
+      true
+    end
+
+    def pending?
+      state == PENDING
+    end
+
+    def can_pend?
+      ready?
     end
 
     self.whitelisted_ransackable_associations = ['order']
@@ -264,13 +337,13 @@ module Spree
     # shipped    if already shipped (ie. does not change the state)
     # ready      all other cases
     def determine_state(order)
-      return 'canceled' if order.canceled?
-      return 'shipped' if shipped?
-      return 'pending' unless order.can_ship?
+      return CANCELED if order.canceled?
+      return SHIPPED if shipped?
+      return PENDING unless order.can_ship?
       if can_transition_from_pending_to_ready?
-        'ready'
+        READY
       else
-        'pending'
+        PENDING
       end
     end
 
@@ -355,7 +428,7 @@ module Spree
           state: new_state,
           updated_at: Time.current
         )
-        after_ship if new_state == 'shipped'
+        after_ship if new_state == SHIPPED
       end
     end
 
@@ -429,6 +502,29 @@ module Spree
         errors.add(:state, :cannot_destroy, state: state)
         throw :abort
       end
+    end
+
+    def store_state_change(previous_state, new_state)
+      state_changes.create!(
+        previous_state: previous_state,
+        next_state:     new_state,
+        name:           'shipment'
+      )
+    end
+
+    def change_state!(new_state)
+      previous_state = state
+      if new_state != previous_state
+        update_attributes(
+          state: new_state,
+          updated_at: Time.current
+        )
+        store_state_change(previous_state, new_state)
+      end
+    end
+
+    def set_default_state
+      self.state ||= PENDING
     end
   end
 end

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -156,16 +156,25 @@ module Spree
     end
 
     def can_transition_from_pending_to_shipped?
+      Spree::Deprecation.warn \
+        'Spree::Shipment#can_transition_from_pending_to_shipped is deprecated. ' \
+        'It is equivalent to the negation of Spree::Shipment#requires_shipment?'
       !requires_shipment?
     end
 
     def can_transition_from_pending_to_ready?
+      Spree::Deprecation.warn \
+        'Spree::Shipment#can_transition_from_pending_to_ready? is deprecated. ' \
+        'Use Spree::Shipment#inventory_can_ship? instead.'
       order.can_ship? &&
         inventory_units.all? { |iu| iu.shipped? || iu.allow_ship? || iu.canceled? } &&
         (order.paid? || !Spree::Config[:require_payment_to_ship])
     end
 
     def can_transition_from_canceled_to_ready?
+      Spree::Deprecation.warn \
+        'Spree::Shipment#can_transition_from_pending_to_ready? is deprecated. ' \
+        'Use Spree::Shipment#inventory_can_ship? instead.'
       can_transition_from_pending_to_ready?
     end
 

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -71,7 +71,7 @@ module Spree
 
     def resume
       return false unless can_resume?
-      can_transition_from_canceled_to_ready? ? change_state!(READY) : change_state!(PENDING)
+      inventory_can_ship? ? change_state!(READY) : change_state!(PENDING)
       after_resume
       true
     end
@@ -107,10 +107,10 @@ module Spree
 
     def ready
       return false unless state == PENDING
-      if can_transition_from_pending_to_shipped?
+      if !requires_shipment?
         change_state!(SHIPPED)
         after_ship
-      elsif can_transition_from_pending_to_ready?
+      elsif inventory_can_ship?
         change_state!(READY)
       else
         return false
@@ -123,7 +123,7 @@ module Spree
     end
 
     def can_ready?
-      pending? && (can_transition_from_pending_to_shipped? || can_transition_from_pending_to_ready?)
+      pending? && (!requires_shipment? || inventory_can_ship?)
     end
 
     def pend!
@@ -148,6 +148,12 @@ module Spree
     self.whitelisted_ransackable_attributes = ['number']
 
     delegate :tax_category, :tax_category_id, to: :selected_shipping_rate, allow_nil: true
+
+    def inventory_can_ship?
+      order.can_ship? &&
+        inventory_units.all? { |iu| iu.shipped? || iu.allow_ship? || iu.canceled? } &&
+        (order.paid? || !Spree::Config[:require_payment_to_ship])
+    end
 
     def can_transition_from_pending_to_shipped?
       !requires_shipment?
@@ -340,7 +346,7 @@ module Spree
       return CANCELED if order.canceled?
       return SHIPPED if shipped?
       return PENDING unless order.can_ship?
-      if can_transition_from_pending_to_ready?
+      if inventory_can_ship?
         READY
       else
         PENDING

--- a/core/spec/models/spree/order/state_machine_spec.rb
+++ b/core/spec/models/spree/order/state_machine_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe Spree::Order, type: :model do
       end
     end
 
-    (Spree::Shipment.state_machine.states.keys - states).each do |shipment_state|
+    ['shipped', 'canceled'].each do |shipment_state|
       it "should be false if shipment_state is #{shipment_state}" do
         expect(order).to be_completed
         order.shipment_state = shipment_state

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -1199,4 +1199,34 @@ RSpec.describe Spree::Shipment, type: :model do
       end
     end
   end
+
+  describe '#inventory_can_ship?' do
+    let(:shipment) { create(:shipment, order: order) }
+
+    subject { shipment.inventory_can_ship? }
+
+    context "with backordered inventory" do
+      before { shipment.inventory_units.update_all(state: "backordered") }
+
+      it "returns false" do
+        expect(subject).to be false
+      end
+    end
+
+    context "with on_hand inventory" do
+      before { shipment.inventory_units.update_all(state: "on_hand") }
+
+      it "returns true" do
+        expect(subject).to be true
+      end
+    end
+
+    context "with shipped inventory" do
+      before { shipment.inventory_units.update_all(state: "shipped") }
+
+      it "returns true" do
+        expect(subject).to be true
+      end
+    end
+  end
 end

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -1170,36 +1170,6 @@ RSpec.describe Spree::Shipment, type: :model do
     end
   end
 
-  describe '#can_transition_from_pending_to_ready?' do
-    let(:shipment) { create(:shipment, order: order) }
-
-    subject { shipment.can_transition_from_pending_to_ready? }
-
-    context "with backordered inventory" do
-      before { shipment.inventory_units.update_all(state: "backordered") }
-
-      it "returns false" do
-        expect(subject).to be false
-      end
-    end
-
-    context "with on_hand inventory" do
-      before { shipment.inventory_units.update_all(state: "on_hand") }
-
-      it "returns true" do
-        expect(subject).to be true
-      end
-    end
-
-    context "with shipped inventory" do
-      before { shipment.inventory_units.update_all(state: "shipped") }
-
-      it "returns true" do
-        expect(subject).to be true
-      end
-    end
-  end
-
   describe '#inventory_can_ship?' do
     let(:shipment) { create(:shipment, order: order) }
 


### PR DESCRIPTION
The [state_machines gem](https://github.com/state-machines/state_machines) has been used throughout Solidus since the earliest days of Spree. We use it to track the "state" our shipments/payments/orders are in, as well as plug custom functionality into the transitions between those states (`before_transition`/`after_transition`). 

However, our use of intermingled state machines between Payments, Shipments and Orders causes problems for both new and established developers. The state machine transitions are difficult to understand and debug, the order the transitions are executed in can be tough to control, and properly controlling database transactions during a transition is very poorly understood. 

We believe the downsides of implementing our state machines using the state_machines gem to be a net negative for the project.

This PR changes the `Spree::Shipment` class, explicitly defining the important methods that would have been generated from the state_machines metaprogramming. The advantages of doing this are improved code clarity, debug-ability, as well as making it more easy to completely override methods regarding state.

The first two commits of this pull request remove the `state_machine` from [`Spree::Shipment`](https://github.com/solidusio/solidus/blob/master/core/app/models/spree/shipment.rb) without changing the external API of the model. The last two commits go a bit further and deprecate the [transition methods](https://github.com/solidusio/solidus/blob/fd474db749d4386f52a23efbb59d30336351028d/core/app/models/spree/shipment.rb#L79-L91) that were used by the state machine in an attempt to improve code readability. If we don't want to go ahead and deprecate the transition methods, the first two commits can just be taken on their own, keeping the external API of [`Spree::Shipment`](https://github.com/solidusio/solidus/blob/master/core/app/models/spree/shipment.rb) intact.

While we could re-implement the `before_transition`/`after_transition` calls on the `Spree::Shipment` model, we believe the following examples would be a better way to support customising functionality before or after a transition (with `ship` used as an example).

```ruby
module AfterShipAction
  # Note that returning true/false is done to preserve the original return values of ship
  # This pattern works for all of ship, resume, pend, ready, and cancel
  def ship
    if super
      additional_after_ship_procedure
    end
  end

  def additional_after_ship_procedure
    # Do something interesting!
    true
  end
end

module BeforeShipCondition
  def ship
    if pre_ship_condition
      super
    end
  end

  def pre_ship_condition
    # Some interesting condition as to when we can ship
    true
  end
end

Spree::Shipment.prepend AfterShipAction
Spree::Shipment.prepend BeforeShipCondition
```